### PR TITLE
Use provided scope for tomcat dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,6 +126,22 @@ war {
 }
 ----
 
+and, if you want to deploy the WAR file to an external container, you
+also need to mark the embedded container dependencies as "provided":
+
+[source,groovy]
+---
+configurations {
+    providedRuntime
+}
+
+dependencies {
+    ...
+    providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
+    ...
+}
+---
+
 This signals Gradle to build a WAR. Here is the new version of the build.gradle:
 
 `build.gradle`

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -24,8 +24,13 @@ repositories {
     maven { url "http://repo.spring.io/libs-snapshot" }
 }
 
+configurations {
+    providedRuntime
+}
+
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-thymeleaf")
+    providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
     testCompile("junit:junit")
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -19,6 +19,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
To make the WAR file deployable (people always seem to assume it will be) as
well as executable, you need the embedded container to _not_ be on the
classpath in an external container.

I believe this fixes gh-10 and probably fixes gh-12
