### PR TITLE
Corrected fragment identifier of URL reference.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ A popular subject is that many people still wish to generate WAR files to be dep
 
 For detailed steps on how to configure your application to create a WAR file for your container, please see:
 
-* {spring_boot_docs}/#build-tool-plugins-maven-packaging[Packaging executable jar and war files with Maven]
+* {spring_boot_docs}/#build-tool-plugins.maven[Packaging executable jar and war files with Maven]
 * {spring_boot_docs}/#build-tool-plugins-gradle-plugin[Spring Boot Gradle Plugin] or
 * https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/#packaging-executable-wars[Gradle Plugin Reference: Packaging executable wars]
 


### PR DESCRIPTION
“@pivotal-cla This is an Obvious Fix” The old fragment identifier of URL to "Packaging executable jar and war files with Maven" doesn't exist anymore. Hence updated with proper fragment identifier.